### PR TITLE
🔒 Fix XSS vulnerability in renderBookmarkList

### DIFF
--- a/LinuxDo-Bookmarks-to-Notion.user.js
+++ b/LinuxDo-Bookmarks-to-Notion.user.js
@@ -13793,6 +13793,8 @@ ${availableTools}
             list.innerHTML = UI.bookmarks.map((b) => {
                 const bookmarkKey = UI.getBookmarkKey(b);
                 const title = b.title || b.name || `帖子 ${bookmarkKey}`;
+                const escapedTitle = Utils.escapeHtml(title);
+                const escapedTruncatedTitle = Utils.escapeHtml(Utils.truncateText(title, 35));
                 const isExported = UI.isBookmarkKeyExported(bookmarkKey);
                 const isSelected = UI.selectedBookmarks?.has(bookmarkKey);
                 const sourceTag = githubMode
@@ -13802,7 +13804,7 @@ ${availableTools}
                 return `
                     <div class="ldb-bookmark-item" data-topic-id="${bookmarkKey}">
                         <input type="checkbox" ${isSelected ? "checked" : ""} ${isExported ? "disabled" : ""}>
-                        <span class="title" title="${title}">${Utils.truncateText(title, 35)}</span>
+                        <span class="title" title="${escapedTitle}">${escapedTruncatedTitle}</span>
                         ${sourceTag}${isExported ? '<span class="status exported">已导出</span>' : '<span class="status pending">待导出</span>'}
                     </div>
                 `;


### PR DESCRIPTION
🎯 **What:** 
Fixed a Cross-Site Scripting (XSS) vulnerability within `renderBookmarkList` in `LinuxDo-Bookmarks-to-Notion.user.js` where bookmark titles were rendered as raw HTML.

⚠️ **Risk:** 
If a bookmark was saved with a malicious title, it could execute arbitrary JavaScript directly in the context of the user's browser via the extension's rendering of `innerHTML`. This could lead to session hijacking, unauthorized actions on the user's behalf, or data exfiltration.

🛡️ **Solution:** 
Sanitized the `title` variable using the existing `Utils.escapeHtml()` function prior to inserting it into the `title` attribute. We apply the same encoding after truncating the string to prevent accidentally splitting encoded characters, fully neutralizing the XSS risk without breaking the rendering of valid bookmarks.

---
*PR created automatically by Jules for task [17275200913151552106](https://jules.google.com/task/17275200913151552106) started by @Smith-106*